### PR TITLE
Fix bad reference to 'buster' global

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -188,7 +188,7 @@ var cg = module.exports = B.extend(B.eventEmitter.create(), {
     create: function (options, rootPath) {
         options = options || {};
         return B.extend(Object.create(this), {
-            config: buster.extend({}, options),
+            config: B.extend({}, options),
             rootPath: Path.resolve(rootPath, options.rootPath),
             server: extractServer(options),
             environment: options.environment || options.env || "browser",


### PR DESCRIPTION
Running `buster static` is failing for me with an error such as:

```
Error loading configuration /path/to/buster.js
buster is not defined
```

I noticed that group.js is referring to `buster` when it should refer to `B`. I've fixed this in the code and confirmed that `buster static` now starts.

(Using all latest versions of gems: buster 0.5.4, buster-cli 0.4.4, buster-configuration 0.4.1, buster-static 0.3.3)
